### PR TITLE
Removed corsheaders from docker devel

### DIFF
--- a/settings/docker_devel.py
+++ b/settings/docker_devel.py
@@ -2,8 +2,6 @@ from .docker import *
 
 STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
 
-INSTALLED_APPS.append("corsheaders")
-
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",


### PR DESCRIPTION
Since this app is already added in base settings, it doesn't need to be repeated here.