### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
Fix for cloning code in windows. 

When cloned to windows (I know, my fault), end of lines get converted to CR LF from LF in docker-entrypoint.sh which makes docker fail to set up backend succesfully. Adding .gitattributes should fix it. 