### PR TITLE
Handle error on Game Sessions creation for already existing one

### DIFF
--- a/games/management/commands/periodic_games_creation.py
+++ b/games/management/commands/periodic_games_creation.py
@@ -34,9 +34,14 @@ class Command(BaseCommand):
             if dow and session_time.date().weekday() != dow:
                 continue
 
-            GameSession.objects.get_or_create(
-                date=session_time.date(),
-                table=table,
-                active=True,
-                spots=table.max_spots,
-            )
+            try:
+                gs, created = GameSession.objects.get_or_create(
+                    date=session_time.date(),
+                    table=table,
+                    active=True,
+                )
+                if created:
+                    gs.spots = table.max_spots
+                    gs.save(update_fields=["spots"])
+            except GameSession.MultipleObjectsReturned:
+                logger.error("Could not create a Game Session for date: %s table id: %s", str(session_time.date()), str(table.id))


### PR DESCRIPTION
Handle Multiple Game Sessions already created, breaking the session creation. Also, fix the situation when the GS is already in the DB but the number of spots has changed.